### PR TITLE
EmitSourceN

### DIFF
--- a/src/internal/CCodegen.scala
+++ b/src/internal/CCodegen.scala
@@ -108,7 +108,7 @@ trait CCodegen extends CLikeCodegen {
     }
   }
       
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], className: String, out: PrintWriter) = {
 
     val sB = manifest[A].toString
 

--- a/src/internal/CCodegen.scala
+++ b/src/internal/CCodegen.scala
@@ -108,12 +108,9 @@ trait CCodegen extends CLikeCodegen {
     }
   }
       
-  def emitSource[A,B](f: Exp[A] => Exp[B], className: String, out: PrintWriter)(implicit mA: Manifest[A], mB: Manifest[B]): List[(Sym[Any], Any)] = {
-    val x = fresh[A]
-    val y = reifyBlock(f(x))
+  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
 
-    val sA = mA.toString
-    val sB = mB.toString
+    val sB = manifest[A].toString
 
     withStream(out) {
       stream.println("/*****************************************\n"+
@@ -126,7 +123,7 @@ trait CCodegen extends CLikeCodegen {
       //stream.println("class "+className+" extends (("+sA+")=>("+sB+")) {")
       stream.println("int main(int argc, char** argv) {")
 
-      emitBlock(y)
+      emitBlock(body)
       //stream.println(quote(getBlockResult(y)))
 
       //stream.println("}")

--- a/src/internal/CudaCodegen.scala
+++ b/src/internal/CudaCodegen.scala
@@ -125,7 +125,7 @@ trait CudaCodegen extends GPUCodegen {
     throw new GenerationFailedException("CudaGen: cloneObject(sym)")
   }
 
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], className: String, out: PrintWriter) = {
 
     val sB = manifest[A].toString
 

--- a/src/internal/CudaCodegen.scala
+++ b/src/internal/CudaCodegen.scala
@@ -125,12 +125,9 @@ trait CudaCodegen extends GPUCodegen {
     throw new GenerationFailedException("CudaGen: cloneObject(sym)")
   }
 
-  def emitSource[A,B](f: Exp[A] => Exp[B], className: String, out: PrintWriter)(implicit mA: Manifest[A], mB: Manifest[B]): List[(Sym[Any], Any)] = {
-    val x = fresh[A]
-    val y = reifyBlock(f(x))
+  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
 
-    val sA = mA.toString
-    val sB = mB.toString
+    val sB = manifest[A].toString
 
     withStream(out) {
       stream.println("/*****************************************\n"+
@@ -142,7 +139,7 @@ trait CudaCodegen extends GPUCodegen {
 
       stream.println("int main(int argc, char** argv) {")
 
-      emitBlock(y)
+      emitBlock(body)
       //stream.println(quote(getBlockResult(y)))
 
       stream.println("}")

--- a/src/internal/GenericCodegen.scala
+++ b/src/internal/GenericCodegen.scala
@@ -99,11 +99,51 @@ trait GenericCodegen extends BlockTraversal {
   def emitNode(sym: Sym[Any], rhs: Def[Any]): Unit = {
     throw new GenerationFailedException("don't know how to generate code for: " + rhs)
   }
-    
+
   def emitValDef(sym: Sym[Any], rhs: String): Unit
-    
-  def emitSource[A,B](f: Exp[A] => Exp[B], className: String, stream: PrintWriter)(implicit mA: Manifest[A], mB: Manifest[B]): List[(Sym[Any], Any)] // return free static data in block
-      
+
+  def emitSource[T : Manifest, R : Manifest](f: Exp[T] => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
+    val s = fresh[T]
+    val body = reifyBlock(f(s))
+    emitSource(List(s->manifest[T]), body, className, stream)
+  }
+
+  def emitSource2[T1 : Manifest, T2 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
+    val s1 = fresh[T1]
+    val s2 = fresh[T2]
+    val body = reifyBlock(f(s1, s2))
+    emitSource(List(s1->manifest[T1], s2->manifest[T2]), body, className, stream)
+  }
+
+  def emitSource3[T1 : Manifest, T2 : Manifest, T3 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
+    val s1 = fresh[T1]
+    val s2 = fresh[T2]
+    val s3 = fresh[T3]
+    val body = reifyBlock(f(s1, s2, s3))
+    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3]), body, className, stream)
+  }
+
+  def emitSource4[T1 : Manifest, T2 : Manifest, T3 : Manifest, T4 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3], Exp[T4]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
+    val s1 = fresh[T1]
+    val s2 = fresh[T2]
+    val s3 = fresh[T3]
+    val s4 = fresh[T4]
+    val body = reifyBlock(f(s1, s2, s3, s4))
+    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3], s4->manifest[T4]), body, className, stream)
+  }
+
+  def emitSource5[T1 : Manifest, T2 : Manifest, T3 : Manifest, T4 : Manifest, T5 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3], Exp[T4], Exp[T5]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
+    val s1 = fresh[T1]
+    val s2 = fresh[T2]
+    val s3 = fresh[T3]
+    val s4 = fresh[T4]
+    val s5 = fresh[T5]
+    val body = reifyBlock(f(s1, s2, s3, s4, s5))
+    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3], s4->manifest[T4], s5->manifest[T5]), body, className, stream)
+  }
+
+  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, stream: PrintWriter): List[(Sym[Any], Any)] // return free static data in block
+
   def quote(x: Exp[Any]) : String = x match {
     case Const(s: String) => "\""+s+"\""
     case Const(c: Char) => "'"+c+"'"

--- a/src/internal/GenericCodegen.scala
+++ b/src/internal/GenericCodegen.scala
@@ -105,14 +105,14 @@ trait GenericCodegen extends BlockTraversal {
   def emitSource[T : Manifest, R : Manifest](f: Exp[T] => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
     val s = fresh[T]
     val body = reifyBlock(f(s))
-    emitSource(List(s->manifest[T]), body, className, stream)
+    emitSource(List(s), body, className, stream)
   }
 
   def emitSource2[T1 : Manifest, T2 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
     val s1 = fresh[T1]
     val s2 = fresh[T2]
     val body = reifyBlock(f(s1, s2))
-    emitSource(List(s1->manifest[T1], s2->manifest[T2]), body, className, stream)
+    emitSource(List(s1, s2), body, className, stream)
   }
 
   def emitSource3[T1 : Manifest, T2 : Manifest, T3 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
@@ -120,7 +120,7 @@ trait GenericCodegen extends BlockTraversal {
     val s2 = fresh[T2]
     val s3 = fresh[T3]
     val body = reifyBlock(f(s1, s2, s3))
-    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3]), body, className, stream)
+    emitSource(List(s1, s2, s3), body, className, stream)
   }
 
   def emitSource4[T1 : Manifest, T2 : Manifest, T3 : Manifest, T4 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3], Exp[T4]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
@@ -129,7 +129,7 @@ trait GenericCodegen extends BlockTraversal {
     val s3 = fresh[T3]
     val s4 = fresh[T4]
     val body = reifyBlock(f(s1, s2, s3, s4))
-    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3], s4->manifest[T4]), body, className, stream)
+    emitSource(List(s1, s2, s3, s4), body, className, stream)
   }
 
   def emitSource5[T1 : Manifest, T2 : Manifest, T3 : Manifest, T4 : Manifest, T5 : Manifest, R : Manifest](f: (Exp[T1], Exp[T2], Exp[T3], Exp[T4], Exp[T5]) => Exp[R], className: String, stream: PrintWriter): List[(Sym[Any], Any)] = {
@@ -139,10 +139,16 @@ trait GenericCodegen extends BlockTraversal {
     val s4 = fresh[T4]
     val s5 = fresh[T5]
     val body = reifyBlock(f(s1, s2, s3, s4, s5))
-    emitSource(List(s1->manifest[T1], s2->manifest[T2], s3->manifest[T3], s4->manifest[T4], s5->manifest[T5]), body, className, stream)
+    emitSource(List(s1, s2, s3, s4, s5), body, className, stream)
   }
 
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, stream: PrintWriter): List[(Sym[Any], Any)] // return free static data in block
+  /**
+   * @param args List of symbols bound to `body`
+   * @param body Block to emit
+   * @param className Name of the generated identifier
+   * @param stream Output stream
+   */
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], className: String, stream: PrintWriter): List[(Sym[Any], Any)] // return free static data in block
 
   def quote(x: Exp[Any]) : String = x match {
     case Const(s: String) => "\""+s+"\""

--- a/src/internal/OpenCLCodegen.scala
+++ b/src/internal/OpenCLCodegen.scala
@@ -162,7 +162,7 @@ trait OpenCLCodegen extends GPUCodegen {
     throw new GenerationFailedException("OpenCLGen: cloneObject(sym)")
   }
 
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], className: String, out: PrintWriter) = {
     val sB = manifest[A].toString
 
     withStream(out) {

--- a/src/internal/OpenCLCodegen.scala
+++ b/src/internal/OpenCLCodegen.scala
@@ -162,12 +162,8 @@ trait OpenCLCodegen extends GPUCodegen {
     throw new GenerationFailedException("OpenCLGen: cloneObject(sym)")
   }
 
-  def emitSource[A,B](f: Exp[A] => Exp[B], className: String, out: PrintWriter)(implicit mA: Manifest[A], mB: Manifest[B]): List[(Sym[Any], Any)] = {
-    val x = fresh[A]
-    val y = reifyBlock(f(x))
-
-    val sA = mA.toString
-    val sB = mB.toString
+  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
+    val sB = manifest[A].toString
 
     withStream(out) {
       stream.println("/*****************************************\n"+
@@ -179,7 +175,7 @@ trait OpenCLCodegen extends GPUCodegen {
 
       stream.println("int main(int argc, char** argv) {")
 
-      emitBlock(y)
+      emitBlock(body)
       //stream.println(quote(getBlockResult(y)))
 
       stream.println("}")

--- a/src/internal/ScalaCodegen.scala
+++ b/src/internal/ScalaCodegen.scala
@@ -19,7 +19,7 @@ trait ScalaCodegen extends GenericCodegen with Config {
       outFile.delete
   }
 
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], className: String, out: PrintWriter) = {
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], className: String, out: PrintWriter) = {
 
     val sA = remap(manifest[A])
 
@@ -31,8 +31,8 @@ trait ScalaCodegen extends GenericCodegen with Config {
                      "*******************************************/")
                    
       // TODO: separate concerns, should not hard code "pxX" name scheme for static data here
-      stream.println("class "+className+(if (staticData.isEmpty) "" else "("+staticData.map(p=>"p"+quote(p._1)+":"+p._1.tp).mkString(",")+")")+" extends (("+args.map(a => remap(a._2)).mkString(", ")+")=>("+sA+")) {")
-      stream.println("def apply("+args.map(a => quote(a._1) + ":" + remap(a._2)).mkString(", ")+"): "+sA+" = {")
+      stream.println("class "+className+(if (staticData.isEmpty) "" else "("+staticData.map(p=>"p"+quote(p._1)+":"+p._1.tp).mkString(",")+")")+" extends (("+args.map(a => remap(a.tp)).mkString(", ")+")=>("+sA+")) {")
+      stream.println("def apply("+args.map(a => quote(a) + ":" + remap(a.tp)).mkString(", ")+"): "+sA+" = {")
     
       emitBlock(body)
       stream.println(quote(getBlockResult(body)))

--- a/test-src/epfl/test5-js/JSCompile.scala
+++ b/test-src/epfl/test5-js/JSCompile.scala
@@ -21,9 +21,9 @@ trait JSCodegen extends GenericCodegen {
     stream.flush
   }
 
-  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], methName: String, out: PrintWriter) = {
+  def emitSource[A : Manifest](args: List[Sym[_]], body: Block[A], methName: String, out: PrintWriter) = {
     withStream(out) {
-      stream.println("function "+methName+"("+args.map(a => quote(a._1)).mkString(", ")+") {")
+      stream.println("function "+methName+"("+args.map(quote).mkString(", ")+") {")
     
       emitBlock(body)
       stream.println("return "+quote(getBlockResult(body)))

--- a/test-src/epfl/test5-js/JSCompile.scala
+++ b/test-src/epfl/test5-js/JSCompile.scala
@@ -21,14 +21,12 @@ trait JSCodegen extends GenericCodegen {
     stream.flush
   }
 
-  def emitSource[A,B](f: Exp[A] => Exp[B], methName: String, out: PrintWriter)(implicit mA: Manifest[A], mB: Manifest[B]): List[(Sym[Any], Any)] = {
-    val x = fresh[A]
-    val y = reifyBlock(f(x))
+  def emitSource[A : Manifest](args: List[(Sym[_], Manifest[_])], body: Block[A], methName: String, out: PrintWriter) = {
     withStream(out) {
-      stream.println("function "+methName+"("+quote(x)+") {")
+      stream.println("function "+methName+"("+args.map(a => quote(a._1)).mkString(", ")+") {")
     
-      emitBlock(y)
-      stream.println("return "+quote(getBlockResult(y)))
+      emitBlock(body)
+      stream.println("return "+quote(getBlockResult(body)))
     
       stream.println("}")
     }


### PR DESCRIPTION
Hi all, I merged some work from [js-scala](https://github.com/js-scala/js-scala/blob/master/src/main/scala/scala/js/JSCompile.scala). It allows to use `emitSource` with functions having other arity than 2.

Some notes:
- The method `emitSource[A : Manifest, B : Manifest](f: Exp[A] => Exp[B], className: String, stream: PrintWriter)` is not abstract anymore so existing code should not override it anymore (or we could declare it as final to enforce this…) ;
- In a second commit I used `Sym#tp` directly to retrieve the `Manifest` associated with a symbol instead of asking the compiler to provide it implicitly. Not sure it’s a good idea but it simplified the signature of the `emitSource` method.
