### PR TITLE
Some work on records

### DIFF
--- a/src/common/Structs.scala
+++ b/src/common/Structs.scala
@@ -247,6 +247,7 @@ trait StructFatExpOptCommon extends StructFatExp with StructExpOptCommon with If
 trait ScalaGenStruct extends ScalaGenBase {
   val IR: StructExp
   import IR._
+  import reflect.RefinedManifest
   
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case Struct(tag, elems) =>
@@ -257,9 +258,9 @@ trait ScalaGenStruct extends ScalaGenBase {
       
       Array --> transform soa back to aos
       */
-      if (sym.tp <:< manifest[Record]) {
-        registerType(sym.tp, elems)
-        emitValDef(sym, recordClassName(sym.tp) + "(" + (for ((n, v) <- elems) yield n + " = " + quote(v)).mkString(", ") + ")")
+      if (sym.tp.isInstanceOf[RefinedManifest[_]] && sym.tp <:< manifest[Record]) {
+        registerType(sym.tp.asInstanceOf[RefinedManifest[Record]], elems)
+        emitValDef(sym, remap(sym.tp) + "(" + (for ((n, v) <- elems) yield n + " = " + quote(v)).mkString(", ") + ")")
       } else {
         emitValDef(sym, "new { " + (for ((n, v) <- elems) yield "val " + n + " = " + quote(v)).mkString("; ") + " }")
       }
@@ -269,26 +270,46 @@ trait ScalaGenStruct extends ScalaGenBase {
   }
 
   // Records generate a class
-  override def remap[A](m: Manifest[A]) = m match {
-    case m if m <:< manifest[Record] => recordClassName(m)
+  override def remap[A](m: Manifest[A]) = indexOfEncountered(m) match {
+    case Some(i) => "C" + i
     case _ => super.remap(m)
   }
 
-  // not public because should not be called with a manifest not describing a subtype of Manifest[Record]
-  protected def recordClassName[A](m: Manifest[A]): String = m match {
-    case rm: reflect.RefinedManifest[A] => rm.erasure.getSimpleName + rm.fields.map(f => recordClassName(f._2)).mkString
-    case _ => m.erasure.getSimpleName + m.typeArguments.map(a => recordClassName(a)).mkString
+  private val encounteredStructs = new collection.mutable.ListBuffer[RefinedManifest[_ <: Record]]
+  private def registerType(m: RefinedManifest[_ <: Record], elems: Map[String, Rep[_]]) {
+    assert(elems.size == m.fields.size, "Record fields don’t contain as many elements as reflected in manifest: %s vs %s".format(elems.size, m.fields.size))
+    for ((n, tp) <- m.fields) {
+      assert(elems.contains(n), "Record field not reflected in manifest: %s".format(n))
+      // assert(elems(n).tp == tp, "Record field type different than the one reflected in manifest: %s vs %s".format(elems(n).tp, tp))
+    }
+    if (indexOfEncountered(m).isEmpty) {
+      encounteredStructs += m
+    }
   }
 
-  private val encounteredStructs = collection.mutable.HashMap.empty[String, Map[String, Exp[_]]]
-  private def registerType[A](m: Manifest[A], fields: Map[String, Exp[_]]) {
-    encounteredStructs += (recordClassName(m) -> fields)
+  /**
+   * Look for a type equivalent to `m` in the already encountered record manifests.
+   */
+  private def indexOfEncountered(m: Manifest[_]): Option[Int] = m match {
+    case rm: RefinedManifest[_] if rm <:< manifest[Record] => {
+      encounteredStructs.foldLeft(Option.empty[Int], 0) { case ((found, i), m) =>
+        def sameManifest(m1: Manifest[_], m2: Manifest[_]): Boolean = (m1, m2) match {
+          case (rm1: RefinedManifest[_], rm2: RefinedManifest[_]) =>
+            rm1 == rm2 && rm1.fields.size == rm2.fields.size && (rm1.fields zip rm2.fields).foldLeft(true) { case (same, (lhs, rhs)) =>
+              same && lhs._1 == rhs._1 && sameManifest(lhs._2, rhs._2)
+            }
+          case _ => m1 == m2
+        }
+        (found.orElse(if (sameManifest(m, rm)) Some(i) else None), i + 1)
+      }._1
+    }
+    case _ => None
   }
 
   def emitDataStructures(out: PrintWriter) {
     withStream(out) {
-      for ((name, fields) <- encounteredStructs) {
-        stream.println("case class " + name + "(" + (for ((n, e) <- fields) yield n + ": " + remap(e.tp)).mkString(", ") + ")")
+      for (m <- encounteredStructs) {
+        stream.println("case class " + remap(m) + "(" + (for ((n, m) <- m.fields) yield n + ": " + remap(m)).mkString(", ") + ")")
       }
     }
   }

--- a/src/common/Structs.scala
+++ b/src/common/Structs.scala
@@ -314,6 +314,13 @@ trait ScalaGenStruct extends ScalaGenBase {
     }
   }
 
+  override def emitDataStructures(path: String) {
+    val out = new PrintWriter(path)
+    emitDataStructures(out)
+    out.close()
+    super.emitDataStructures(path)
+  }
+
 }
 
 trait CudaGenStruct extends CudaGenBase {

--- a/test-out/epfl/test9-struct1.check
+++ b/test-out/epfl/test9-struct1.check
@@ -21,4 +21,4 @@ x17
 /*****************************************
   End of Generated Code                  
 *******************************************/
-case class C0(re: Double, im: Double)
+case class C0(re: Int, im: Double)

--- a/test-out/epfl/test9-struct5.check
+++ b/test-out/epfl/test9-struct5.check
@@ -3,22 +3,15 @@
 *******************************************/
 class Test extends ((Int)=>(Unit)) {
 def apply(x0:Int): Unit = {
-var x2: Int = x0
-var x3: Double = 0.0
-val x5 = x2
-val x6 = x3
-val x9 = x5+0.0
-x2 = x9
-val x10 = x6+x0
-x3 = x10
-val x14 = x2
-val x15 = x3
-val x16 = C0(re = x14, im = x15)
-val x17 = println(x16)
-x17
+val x1 = C0(x = 1.0, y = 2.0)
+val x2 = println(x1)
+val x3 = C1(re = 3.0, im = 4.0)
+val x4 = println(x3)
+x4
 }
 }
 /*****************************************
   End of Generated Code                  
 *******************************************/
-case class C0(re: Double, im: Double)
+case class C0(x: Double, y: Double)
+case class C1(re: Double, im: Double)

--- a/test-out/epfl/test9-struct6.check
+++ b/test-out/epfl/test9-struct6.check
@@ -3,19 +3,11 @@
 *******************************************/
 class Test extends ((Int)=>(Unit)) {
 def apply(x0:Int): Unit = {
-var x2: Int = x0
-var x3: Double = 0.0
-val x5 = x2
-val x6 = x3
-val x9 = x5+0.0
-x2 = x9
-val x10 = x6+x0
-x3 = x10
-val x14 = x2
-val x15 = x3
-val x16 = C0(re = x14, im = x15)
-val x17 = println(x16)
-x17
+val x1 = C0(re = 1.0, im = 2.0)
+val x2 = println(x1)
+val x3 = C0(re = 3.0, im = 4.0)
+val x4 = println(x3)
+x4
 }
 }
 /*****************************************

--- a/test-src/epfl/test9-experimental/TestStruct.scala
+++ b/test-src/epfl/test9-experimental/TestStruct.scala
@@ -29,7 +29,6 @@ trait ComplexBase extends Arith with Structs {
   def Complex(r: Rep[Double], i: Rep[Double]): Rep[Complex] = new Record { val re = r; val im = i }
 }
 
-
 // ------ struct impl follows, will move to common once stable
 
 trait StructExpOptLoops extends StructExpOptCommon with ArrayLoopsExp {
@@ -238,4 +237,45 @@ class TestStruct extends FileDiffSuite {
     assertFileEqualsCheck(prefix+"struct4")
   }
 
+  // Two classes are generated if the refined type’s fields have the same type but different names
+  def testStruct5 = {
+    withOutFile(prefix+"struct5") {
+
+      trait Vectors extends Structs {
+        type Vector2D = Record { val x: Double; val y: Double }
+        def Vector2D(px: Rep[Double], py: Rep[Double]): Rep[Vector2D] = new Record { val x = px; val y = py }
+      }
+
+      trait Prog extends DSL with Vectors {
+        def test(x: Rep[Int]) = {
+          print(Vector2D(1, 2))
+          print(Complex(3, 4))
+        }
+      }
+
+      (new Prog with Impl).codegen.emitDataStructures(new PrintWriter(System.out))
+    }
+    assertFileEqualsCheck(prefix+"struct5")
+  }
+
+  // Only one class is generated if refined types are equivalent (their fields have the same names and types)
+  def testStruct6 = {
+    withOutFile(prefix+"struct6") {
+
+      trait Complex2 extends Arith with Structs {
+        type Complex2 = Record { val re: Double; val im: Double }
+        def Complex2(r: Rep[Double], i: Rep[Double]): Rep[Complex2] = new Record { val re = r; val im = i }
+      }
+
+      trait Prog extends DSL with Complex2 {
+        def test(x: Rep[Int]) = {
+          print(Complex2(1, 2))
+          print(Complex(3, 4))
+        }
+      }
+
+      (new Prog with Impl).codegen.emitDataStructures(new PrintWriter(System.out))
+    }
+    assertFileEqualsCheck(prefix+"struct6")
+  }
 }


### PR DESCRIPTION
This patch allows to use records having fields with the same type (and possibly different names) without clash.
