### PR TITLE
#1 Allow more heterogenous types in numeric operations

### DIFF
--- a/test-src/epfl/test11-shonan/TestHMM.scala
+++ b/test-src/epfl/test11-shonan/TestHMM.scala
@@ -77,7 +77,7 @@ class TestHMM extends FileDiffSuite {
               if ((a(i) filter (_ != 0)).length < 3) {
                 for (j <- 0 until n: Range) {
                   if (a(i)(j) != 0)
-                    v1(i) = v1(i) + unit(a(i)(j)) * v(j)
+                    v1(i) = v1(i) + a(i)(j) * v(j)
                 }
               } else {
                 for (j <- 0 until n: Rep[Range]) {

--- a/test-src/epfl/test11-shonan/TestHMM.scala
+++ b/test-src/epfl/test11-shonan/TestHMM.scala
@@ -77,7 +77,7 @@ class TestHMM extends FileDiffSuite {
               if ((a(i) filter (_ != 0)).length < 3) {
                 for (j <- 0 until n: Range) {
                   if (a(i)(j) != 0)
-                    v1(i) = v1(i) + a(i)(j) * v(j)
+                    v1(i) = v1(i) + unit(a(i)(j)) * v(j)
                 }
               } else {
                 for (j <- 0 until n: Rep[Range]) {

--- a/test-src/epfl/test13-numeric/TestNumeric.scala
+++ b/test-src/epfl/test13-numeric/TestNumeric.scala
@@ -20,12 +20,10 @@ trait TestNumeric {
 
   trait UsageWithLift { this: Base with NumericOps with LiftNumeric =>
 
-    // val a = 1 + unit(1)
-    val a = anyToNumericOps(1) + unit(1)
+    val a = 1 + unit(1)
     typed[Rep[Int]](a)
 
-    // val b = 1.0 + unit(1.0)
-    val b = anyToNumericOps(1.0) + unit(1.0)
+    val b = 1.0 + unit(1.0)
     typed[Rep[Double]](b)
 
     val c = unit(1) + 1
@@ -50,15 +48,13 @@ trait TestNumeric {
     typed[Rep[Double]](a)
 
     // val b = 1 + unit(1.0)
-    val b = anyToNumericOps(1) + unit(1.0)
-    typed[Rep[Double]](b)
+    // typed[Rep[Double]](b)
 
     val c = unit(1.0) + 1
     typed[Rep[Double]](c)
-    // val d = 1.0 + unit(1)
 
-    val d = anyToNumericOps(1.0) + unit(1)
-    typed[Rep[Double]](d)
+    // val d = 1.0 + unit(1)
+    // typed[Rep[Double]](d)
   }
 
 }

--- a/test-src/epfl/test13-numeric/TestNumeric.scala
+++ b/test-src/epfl/test13-numeric/TestNumeric.scala
@@ -1,0 +1,64 @@
+package scala.virtualization.lms
+package epfl
+package test13
+
+import common._
+
+// Does nothing but checks the code compiles
+trait TestNumeric {
+
+  def typed[A](a: => A) {}
+
+  trait Usage { this: Base with NumericOps =>
+
+    val a = unit(1) + unit(1)
+    typed[Rep[Int]](a)
+
+    val b = unit(1.0) + unit(1.0)
+    typed[Rep[Double]](b)
+  }
+
+  trait UsageWithLift { this: Base with NumericOps with LiftNumeric =>
+
+    // val a = 1 + unit(1)
+    val a = anyToNumericOps(1) + unit(1)
+    typed[Rep[Int]](a)
+
+    // val b = 1.0 + unit(1.0)
+    val b = anyToNumericOps(1.0) + unit(1.0)
+    typed[Rep[Double]](b)
+
+    val c = unit(1) + 1
+    typed[Rep[Int]](c)
+
+    val d = unit(1.0) + 1.0
+    typed[Rep[Double]](d)
+  }
+
+  trait UsageWithPromotions { this: Base with NumericOps with NumericPromotions =>
+
+    val a = unit(1) + unit(1.0)
+    typed[Rep[Double]](a)
+
+    val b = unit(1.0) + unit(1)
+    typed[Rep[Double]](b)
+  }
+
+  trait UsageWithPromotionsAndLift { this: Base with NumericOps with NumericPromotions with LiftNumeric =>
+
+    val a = unit(1) + 1.0
+    typed[Rep[Double]](a)
+
+    // val b = 1 + unit(1.0)
+    val b = anyToNumericOps(1) + unit(1.0)
+    typed[Rep[Double]](b)
+
+    val c = unit(1.0) + 1
+    typed[Rep[Double]](c)
+    // val d = 1.0 + unit(1)
+
+    val d = anyToNumericOps(1.0) + unit(1)
+    typed[Rep[Double]](d)
+  }
+
+}


### PR DESCRIPTION
Hi,

Here is another attempt to resolve this issue. I’m using a pattern like `CanBuildFrom` to express what the return type of a numeric operation should be. That allows to express type promotion (e.g. `Int` to `Float`) in a clean way.

Unfortunately I’m unable to make things like `1 + unit(1)` working… The `anyToNumericOps` implicit conversion does not seem to be applied automatically.
