### PR TITLE
#23 Fix names of generated classes for Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ more seamless.
 ### How to build:
 
 1. Install the simple build tool ([SBT](http://www.scala-sbt.org/)). 
-You will need version 0.12-Beta2: [sbt-launch.jar](http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.0-Beta2/sbt-launch.jar). 
+You will need a version 0.12.0 of the [sbt-launch.jar](http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12.0/sbt-launch.jar). 
 Follow the [installation instructions](http://www.scala-sbt.org/download.html#manual) on the SBT website.
 
 2. Run `sbt test` to run the test suite.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 #Project properties
-sbt.version=0.12.0-Beta2
+sbt.version=0.12.0

--- a/src/common/Structs.scala
+++ b/src/common/Structs.scala
@@ -303,19 +303,13 @@ trait ScalaGenStruct extends ScalaGenBase {
     }
   }
 
-  def emitDataStructures(out: PrintWriter) {
+  override def emitDataStructures(out: PrintWriter) {
     withStream(out) {
       for ((m, name) <- encounteredStructs) {
         stream.println("case class " + name + "(" + (for ((n, tp) <- m.fields) yield n + ": " + remap(tp)).mkString(", ") + ")")
       }
     }
-  }
-
-  override def emitDataStructures(path: String) {
-    val out = new PrintWriter(path)
-    emitDataStructures(out)
-    out.close()
-    super.emitDataStructures(path)
+    super.emitDataStructures(out)
   }
 
 }

--- a/src/internal/GenericCodegen.scala
+++ b/src/internal/GenericCodegen.scala
@@ -23,8 +23,14 @@ trait GenericCodegen extends BlockTraversal {
   def finalizeGenerator(): Unit = {}
   def kernelInit(syms: List[Sym[Any]], vals: List[Sym[Any]], vars: List[Sym[Any]], resultIsVar: Boolean): Unit = {}
 
-  def emitDataStructures(path: String): Unit = {}
- 
+  def emitDataStructures(path: String): Unit = {
+    val out = new PrintWriter(path)
+    emitDataStructures(out)
+    out.close()
+  }
+
+  def emitDataStructures(out: PrintWriter): Unit = {}
+
   def dataPath = {
     "data" + java.io.File.separator
   }

--- a/src/internal/ScalaCompile.scala
+++ b/src/internal/ScalaCompile.scala
@@ -54,7 +54,9 @@ trait ScalaCompile extends Expressions {
     compileCount += 1
     
     val source = new StringWriter()
-    val staticData = codegen.emitSource(f, className, new PrintWriter(source))
+    val out = new PrintWriter(source)
+    val staticData = codegen.emitSource(f, className, out)
+    codegen.emitDataStructures(out)
 
     val compiler = this.compiler
     val run = new compiler.Run

--- a/test-out/epfl/test9-struct1.check
+++ b/test-out/epfl/test9-struct1.check
@@ -13,7 +13,7 @@ val x10 = x6+x0
 x3 = x10
 val x14 = x2
 val x15 = x3
-val x16 = C0(re = x14, im = x15)
+val x16 = C938825598(re = x14, im = x15)
 val x17 = println(x16)
 x17
 }
@@ -21,4 +21,4 @@ x17
 /*****************************************
   End of Generated Code                  
 *******************************************/
-case class C0(re: Int, im: Double)
+case class C938825598(re: Double, im: Double)

--- a/test-out/epfl/test9-struct5.check
+++ b/test-out/epfl/test9-struct5.check
@@ -3,9 +3,9 @@
 *******************************************/
 class Test extends ((Int)=>(Unit)) {
 def apply(x0:Int): Unit = {
-val x1 = C0(x = 1.0, y = 2.0)
+val x1 = C1162549396(x = 1.0, y = 2.0)
 val x2 = println(x1)
-val x3 = C1(re = 3.0, im = 4.0)
+val x3 = C938825598(re = 3.0, im = 4.0)
 val x4 = println(x3)
 x4
 }
@@ -13,5 +13,5 @@ x4
 /*****************************************
   End of Generated Code                  
 *******************************************/
-case class C0(x: Double, y: Double)
-case class C1(re: Double, im: Double)
+case class C1162549396(x: Double, y: Double)
+case class C938825598(re: Double, im: Double)

--- a/test-out/epfl/test9-struct6.check
+++ b/test-out/epfl/test9-struct6.check
@@ -3,9 +3,9 @@
 *******************************************/
 class Test extends ((Int)=>(Unit)) {
 def apply(x0:Int): Unit = {
-val x1 = C0(re = 1.0, im = 2.0)
+val x1 = C938825598(re = 1.0, im = 2.0)
 val x2 = println(x1)
-val x3 = C0(re = 3.0, im = 4.0)
+val x3 = C938825598(re = 3.0, im = 4.0)
 val x4 = println(x3)
 x4
 }
@@ -13,4 +13,4 @@ x4
 /*****************************************
   End of Generated Code                  
 *******************************************/
-case class C0(re: Double, im: Double)
+case class C938825598(re: Double, im: Double)


### PR DESCRIPTION
Fixes #23 and pulls `emitDataStructures` up to `GenericCodegen` (so it can be called by `ScalaCompile`)
