### PR TITLE
Port branch to Scala 2.10, make tests compile again, bump version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,7 @@ version := "0.2"
 
 organization := "EPFL"
 
-resolvers += ScalaToolsSnapshots
-
-resolvers += dropboxScalaTestRepo
-
-scalaOrganization := "org.scala-lang"
-
-//scalaBinaryVersion := virtScala // necessary??
+scalaOrganization := "org.scala-lang.virtualized"
 
 scalaVersion := virtScala
 
@@ -25,11 +19,11 @@ scalacOptions += "-Yvirtualize"
 //scalacOptions in Compile ++= Seq(/*Unchecked, */Deprecation)
 
 // needed for scala.tools, which is apparently not included in sbt's built in version
-libraryDependencies += "org.scala-lang" % "scala-library" % virtScala
+libraryDependencies += "org.scala-lang.virtualized" % "scala-library" % virtScala
 
-libraryDependencies += "org.scala-lang" % "scala-compiler" % virtScala
+libraryDependencies += "org.scala-lang.virtualized" % "scala-compiler" % virtScala
 
-libraryDependencies += scalaTest
+libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test"
 
 // tests are not thread safe
 parallelExecution in Test := false
@@ -40,6 +34,6 @@ publishArtifact in (Compile, packageDoc) := false
 // continuations
 autoCompilerPlugins := true
 
-addCompilerPlugin("org.scala-lang.plugins" % "continuations" % virtScala)
+addCompilerPlugin("org.scala-lang.virtualized.plugins" % "continuations" % virtScala)
 
 scalacOptions += "-P:continuations:enable"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "LMS"
 
-version := "0.2"
+version := "0.2-wip-merge-SNAPSHOT"
 
 organization := "EPFL"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,10 +2,7 @@ import sbt._
 import java.io.File
 
 object LMSBuild extends Build {
-  // FIXME: custom-built scalatest
-  val dropboxScalaTestRepo = "Dropbox" at "http://dl.dropbox.com/u/12870350/scala-virtualized"
-  val scalaTest = "org.scalatest" % "scalatest_2.10.0-virtualized-SNAPSHOT" % "1.6.1-SNAPSHOT" % "test"
-  val virtScala = Option(System.getenv("SCALA_VIRTUALIZED_VERSION")).getOrElse("2.10.0-M1-virtualized")
+  val virtScala = Option(System.getenv("SCALA_VIRTUALIZED_VERSION")).getOrElse("2.10.0")
 
   lazy val lms = Project("LMS", file("."))
 }

--- a/src/common/ArrayOps.scala
+++ b/src/common/ArrayOps.scala
@@ -96,13 +96,13 @@ trait ArrayOpsExp extends ArrayOps with EffectExp with VariablesExp {
   // mirroring
 
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
-    case ArrayApply(a,x) => array_apply(f(a),f(x))
+    case ArrayApply(a,x) => array_apply(f(a),f(x))(mtype(manifest[A]),pos)
     case ArrayLength(x) => array_length(f(x))
     case e@ArraySort(x) => array_sort(f(x))(e.m,pos)
     case e@ArrayCopy(a,ap,d,dp,l) => toAtom(ArrayCopy(f(a),f(ap),f(d),f(dp),f(l))(e.m))(mtype(manifest[A]),pos)
     case Reflect(e@ArrayNew(n), u, es) => reflectMirrored(Reflect(ArrayNew(f(n))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))    
     case Reflect(e@ArrayLength(x), u, es) => reflectMirrored(Reflect(ArrayLength(f(x))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))    
-    case Reflect(ArrayApply(l,r), u, es) => reflectMirrored(Reflect(ArrayApply(f(l),f(r)), mapOver(f,u), f(es)))(mtype(manifest[A]))
+    case Reflect(ArrayApply(l,r), u, es) => reflectMirrored(Reflect(ArrayApply(f(l),f(r))(mtype(manifest[A])), mapOver(f,u), f(es)))(mtype(manifest[A]))
     case Reflect(e@ArraySort(x), u, es) => reflectMirrored(Reflect(ArraySort(f(x))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))
     case Reflect(ArrayUpdate(l,i,r), u, es) => reflectMirrored(Reflect(ArrayUpdate(f(l),f(i),f(r)), mapOver(f,u), f(es)))(mtype(manifest[A]))   
     case Reflect(e@ArrayCopy(a,ap,d,dp,l), u, es) => reflectMirrored(Reflect(ArrayCopy(f(a),f(ap),f(d),f(dp),f(l))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))     

--- a/src/common/CastingOps.scala
+++ b/src/common/CastingOps.scala
@@ -18,17 +18,18 @@ trait CastingOps extends Variables with OverloadHack {
   }
 
   def rep_isinstanceof[A,B](lhs: Rep[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) : Rep[Boolean]
-  def rep_asinstanceof[A,B:Manifest](lhs: Rep[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) : Rep[B]
+  def rep_asinstanceof[A,B](lhs: Rep[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) : Rep[B]
 }
 
 trait CastingOpsExp extends CastingOps with BaseExp {
   this: ImplicitOps =>
 
   case class RepIsInstanceOf[A,B](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B]) extends Def[Boolean]
-  case class RepAsInstanceOf[A,B:Manifest](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B]) extends Def[B]
+  case class RepAsInstanceOf[A,B](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B]) extends Def[B]
 
   def rep_isinstanceof[A,B](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) = RepIsInstanceOf(lhs,mA,mB)
-  def rep_asinstanceof[A,B:Manifest](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) : Exp[B] = RepAsInstanceOf(lhs,mA,mB)
+  def rep_asinstanceof[A,B](lhs: Exp[A], mA: Manifest[A], mB: Manifest[B])(implicit pos: SourceContext) : Exp[B] = toAtom(RepAsInstanceOf(lhs,mA,mB))(mB,pos)
+
 
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
     case RepAsInstanceOf(lhs, mA, mB) => rep_asinstanceof(f(lhs), mA,mB)

--- a/src/common/ImplicitOps.scala
+++ b/src/common/ImplicitOps.scala
@@ -22,7 +22,7 @@ trait ImplicitOpsExp extends ImplicitOps with BaseExp {
   }
 
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
-    case im@ImplicitConvert(x) => toAtom(ImplicitConvert(f(x))(im.mX,im.mY))
+    case im@ImplicitConvert(x) => toAtom(ImplicitConvert(f(x))(im.mX,im.mY))(mtype(manifest[A]),pos)
     case _ => super.mirror(e,f)
   }).asInstanceOf[Exp[A]]
 

--- a/src/common/NumericOps.scala
+++ b/src/common/NumericOps.scala
@@ -55,10 +55,10 @@ trait NumericOpsExp extends NumericOps with VariablesExp with BaseFatExp {
   def numeric_divide[T:Numeric:Manifest](lhs: Exp[T], rhs: Exp[T])(implicit pos: SourceContext) : Exp[T] = NumericDivide(lhs, rhs)
   
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = e match {
-    case e@NumericPlus(l,r) => numeric_plus(f(l), f(r))(e.aev, e.mev, pos)
-    case e@NumericMinus(l,r) => numeric_minus(f(l), f(r))(e.aev, e.mev, pos)
-    case e@NumericTimes(l,r) => numeric_times(f(l), f(r))(e.aev, e.mev, pos)
-    case e@NumericDivide(l,r) => numeric_divide(f(l), f(r))(e.aev, e.mev, pos)
+    case e@NumericPlus(l,r) => numeric_plus(f(l), f(r))(e.aev.asInstanceOf[Numeric[A]], mtype(e.mev), pos)
+    case e@NumericMinus(l,r) => numeric_minus(f(l), f(r))(e.aev.asInstanceOf[Numeric[A]], mtype(e.mev), pos)
+    case e@NumericTimes(l,r) => numeric_times(f(l), f(r))(e.aev.asInstanceOf[Numeric[A]], mtype(e.mev), pos)
+    case e@NumericDivide(l,r) => numeric_divide(f(l), f(r))(e.aev.asInstanceOf[Numeric[A]], mtype(e.mev), pos)
     case _ => super.mirror(e,f)
   }
 

--- a/src/common/ObjectOps.scala
+++ b/src/common/ObjectOps.scala
@@ -38,10 +38,10 @@ trait ObjectOpsExp extends ObjectOps with VariablesExp {
   // mirroring
 
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
-    case e@ObjectUnsafeImmutable(a) => object_unsafe_immutable(f(a))(e.m,pos)
+    case e@ObjectUnsafeImmutable(a) => object_unsafe_immutable(f(a))(mtype(e.m),pos)
     case e@ObjectToString(a) => object_toString(f(a))
-    case Reflect(e@ObjectUnsafeImmutable(a), u, es) => reflectMirrored(Reflect(ObjectUnsafeImmutable(f(a))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))
-    case Reflect(e@ObjectUnsafeMutable(a), u, es) => reflectMirrored(Reflect(ObjectUnsafeMutable(f(a))(e.m), mapOver(f,u), f(es)))(mtype(manifest[A]))
+    case Reflect(e@ObjectUnsafeImmutable(a), u, es) => reflectMirrored(Reflect(ObjectUnsafeImmutable(f(a))(mtype(e.m)), mapOver(f,u), f(es)))(mtype(manifest[A]))
+    case Reflect(e@ObjectUnsafeMutable(a), u, es) => reflectMirrored(Reflect(ObjectUnsafeMutable(f(a))(mtype(e.m)), mapOver(f,u), f(es)))(mtype(manifest[A]))
     case _ => super.mirror(e,f)
   }).asInstanceOf[Exp[A]]
 

--- a/src/common/Structs.scala
+++ b/src/common/Structs.scala
@@ -108,7 +108,7 @@ trait StructExp extends StructOps with BaseExp with EffectExp with VariablesExp 
   }
 
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
-    case SimpleStruct(tag, elems) => struct(tag, elems map { case (k,v) => (k, f(v)) })
+    case SimpleStruct(tag, elems) => struct(tag, elems map { case (k,v) => (k, f(v)) })(mtype(manifest[A]),pos)
     case FieldApply(struct, key) => field(f(struct), key)
     case Reflect(FieldApply(struct, key), u, es) => reflectMirrored(Reflect(FieldApply(f(struct), key), mapOver(f,u), f(es)))(mtype(manifest[A]))
     case Reflect(FieldUpdate(struct, key, rhs), u, es) => reflectMirrored(Reflect(FieldUpdate(f(struct), key, f(rhs)), mapOver(f,u), f(es)))(mtype(manifest[A]))

--- a/test-src/epfl/test10-transform/TestBackward.scala
+++ b/test-src/epfl/test10-transform/TestBackward.scala
@@ -151,7 +151,7 @@ trait TestDSL extends BaseExp with LiftAll {
   def flowBwd[T](e: Effects, block: BlockStm[T]) = {
     var ee = e ++ List(block.res.toString)
     val stms2 = block.stms.reverse.flatMap {
-      case TP(sym, WaitBwd(e, r)) =>
+      case TP(sym, WaitBwd(e, r: ((Sym[Any], BwdInfo) => (List[Stm], BwdInfo)))) => // FIXME: type annot?
         val (stm2, ee2) = r(sym, e)
         ee = ee2
         stm2

--- a/test-src/epfl/test10-transform/TestWorklistTransform2.scala
+++ b/test-src/epfl/test10-transform/TestWorklistTransform2.scala
@@ -77,7 +77,7 @@ trait VectorExpTrans2 extends FWTransform2 with VectorExp with ArrayLoopsExp wit
 
   override def onCreate[A:Manifest](s: Sym[A], d: Def[A]) = (d match {
     case VectorZeros(n)   => s.atPhase(xform) { vzeros_xform(xform(n)).asInstanceOf[Exp[A]] }
-    case VectorApply(a,x) => s.atPhase(xform) { vapply_xform(xform(a), xform(x)).asInstanceOf[Exp[A]] }
+    case VectorApply(a,x) => s.atPhase(xform) { vapply_xform(xform(a), xform(x))(mtype(manifest[A])).asInstanceOf[Exp[A]] }
     case VectorLength(x)  => s.atPhase(xform) { vlength_xform(xform(x)).asInstanceOf[Exp[A]] }
     case VectorPlus(a,b)  => s.atPhase(xform) { vplus_xform(xform(a),xform(b)).asInstanceOf[Exp[A]] }
     case _ => super.onCreate(s,d)

--- a/test-src/epfl/test10-transform/Vectors.scala
+++ b/test-src/epfl/test10-transform/Vectors.scala
@@ -56,7 +56,7 @@ trait VectorExp extends VectorOps with EffectExp {
   override def mirror[A:Manifest](e: Def[A], f: Transformer)(implicit pos: SourceContext): Exp[A] = (e match {
     case VectorZeros(n) => vzeros(f(n))
     case VectorLiteral(a) => vliteral(f(a))
-    case VectorApply(a,x) => vapply(f(a),f(x))
+    case VectorApply(a,x) => vapply(f(a),f(x))(mtype(manifest[A]))
     case VectorUpdate(a,x,y) => vupdate(f(a),f(x),f(y))
     case VectorLength(a) => vlength(f(a))
     case VectorPlus(a, b) => vplus(f(a),f(b))

--- a/test-src/epfl/test4-functions/FooBar.scala
+++ b/test-src/epfl/test4-functions/FooBar.scala
@@ -35,7 +35,8 @@ trait FooB {
 
   object IsSym {
     def unapply[U](x: Exp[U]): Option[Sym[U]] = x match {
-      case s @ Sym() => Some(s)
+//2.10 M%      case s @ Sym() => Some(s)
+      case s: Sym[U] => Some(s)
       case _ => None
     }
   }
@@ -43,7 +44,8 @@ trait FooB {
   def eval[A](term: Exp[A]): Const[A] = term match {
     case IsSym(Lookup(c)) => c
 //    case Lookup(c) => c
-    case c @ Const() => c
+//2.10 M5    case c @ Const() => c
+    case c: Const[A] => c
   }
 
 }

--- a/test-src/epfl/test5-js/JSCompile.scala
+++ b/test-src/epfl/test5-js/JSCompile.scala
@@ -37,6 +37,10 @@ trait JSCodegen extends GenericCodegen {
   def emitValDef(sym: Sym[Any], rhs: String): Unit = {
     stream.println("var " + quote(sym) + " = " + rhs)
   }
+
+  def emitAssignment(lhs: String, rhs: String): Unit = {
+    stream.println(lhs + " = " + rhs)
+  }
 }
 
 trait JSNestedCodegen extends GenericNestedCodegen with JSCodegen {

--- a/test-src/epfl/test5-js/TestFunctions.scala
+++ b/test-src/epfl/test5-js/TestFunctions.scala
@@ -54,11 +54,21 @@ trait JSGenTupleOps extends JSGenBase {
   import IR._
 
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
-    case ETuple2(a,b)  =>
-      emitValDef(sym, "{_1:"+ quote(a) + ",_2:" + quote(b) + "}")
-    case Tuple2Access1(t) => emitValDef(sym, quote(t) + "._1")
-    case Tuple2Access2(t) => emitValDef(sym, quote(t) + "._2")
 
+    // The patterns
+    //
+    // case ETuple2(a,b)  =>
+    // case Tuple2Access2(t) =>
+    // case Tuple2Access2(t) =>
+    //
+    // are converted to be compilable after
+    //
+    // virtualization-lms-core/commit/e6b9ea00be575001c74cae67c2fbda195172ee2f
+
+    case SimpleStruct(ClassTag(name), Seq(a_kv, b_kv)) if (name startsWith "Tuple2") =>
+      emitValDef(sym, "{_1:"+ quote(a_kv._2) + ",_2:" + quote(b_kv._2) + "}")
+    case FieldApply(t, "_1") => emitValDef(sym, quote(t) + "._1")
+    case FieldApply(t, "_2") => emitValDef(sym, quote(t) + "._2")
     case _ => super.emitNode(sym, rhs)
   }
 }

--- a/test-src/epfl/test9-experimental/TestStruct.scala
+++ b/test-src/epfl/test9-experimental/TestStruct.scala
@@ -35,7 +35,7 @@ trait ComplexBase extends Arith {
 
 trait ComplexStructExp extends ComplexBase with StructExp {
 
-  def Complex(re: Rep[Double], im: Rep[Double]) = struct[Complex](ClassTag[Complex]("Complex"), Map("re"->re, "im"->im))
+  def Complex(re: Rep[Double], im: Rep[Double]) = struct[Complex](ClassTag[Complex]("Complex"), "re"->re, "im"->im)
   def infix_re(c: Rep[Complex]): Rep[Double] = field[Double](c, "re")
   def infix_im(c: Rep[Complex]): Rep[Double] = field[Double](c, "im")
   
@@ -67,7 +67,7 @@ trait StructExpOptLoops extends StructExpOptCommon with ArrayLoopsExp {
           if (m.erasure.isArray) mtype(Manifest.classType(m.erasure.getComponentType))
           else { printerr("warning: expect type Array[A] but got "+m); mtype(manifest[Any]) }
       }
-      struct[T](tag.asInstanceOf[StructTag[T]], elems.map(p=>(p._1,infix_at(p._2, i)(unwrap(p._2.tp)))))
+      struct[T](tag.asInstanceOf[StructTag[T]], elems.map(p=>(p._1,infix_at(p._2, i)(unwrap(p._2.tp))))(Seq.canBuildFrom))
     case _ => super.infix_at(a,i)
   }
   


### PR DESCRIPTION
The port is done by cherry-picking changes from main.
Unsurprisingly, tests currently only compile, but some fail; I did not investigate this further.
