### PR TITLE
Fixing the testsuite for Windows

### DIFF
--- a/src/internal/ScalaCompile.scala
+++ b/src/internal/ScalaCompile.scala
@@ -25,13 +25,14 @@ trait ScalaCompile extends Expressions {
       val writer = new PrintWriter(new OutputStreamWriter(output))
     */
     val settings = new Settings()
+	val pathSeparator = System.getProperty("path.separator")
 
     settings.classpath.value = this.getClass.getClassLoader match {
-      case ctx: java.net.URLClassLoader => ctx.getURLs.map(_.getPath).mkString(":")
+      case ctx: java.net.URLClassLoader => ctx.getURLs.map(_.getPath).mkString(pathSeparator)
       case _ => System.getProperty("java.class.path")
     }
     settings.bootclasspath.value = Predef.getClass.getClassLoader match {
-      case ctx: java.net.URLClassLoader => ctx.getURLs.map(_.getPath).mkString(":")
+      case ctx: java.net.URLClassLoader => ctx.getURLs.map(_.getPath).mkString(pathSeparator)
       case _ => System.getProperty("sun.boot.class.path")
     }
     settings.encoding.value = "UTF-8"

--- a/test-src/epfl/FileDiffSuite.scala
+++ b/test-src/epfl/FileDiffSuite.scala
@@ -33,11 +33,10 @@ trait FileDiffSuite extends Suite {
   }
   
   def readFile(name: String): String = {
-    val buf = new Array[Byte](new File(name).length().toInt)
-    val fis = new FileInputStream(name)
-    fis.read(buf)
-    fis.close()
-    new String(buf)
+    val source = scala.io.Source.fromFile(name)
+    val lines = source.getLines.mkString("\n")
+    source.close()
+    lines
   }
   def assertFileEqualsCheck(name: String): Unit = {
     assert(readFile(name) == readFile(name+".check"), name) // TODO: diff output


### PR DESCRIPTION
- I did change FileDiffSuite#readFile that it does not depend on the line endings
- In ScalaCompile I did did take a generic path separator instead of ":" (which is *ix specific)
