### PR TITLE
Extending support of C++11 lambda expression code generation

### DIFF
--- a/src/common/Functions.scala
+++ b/src/common/Functions.scala
@@ -346,12 +346,10 @@ trait CGenFunctions extends CGenEffect with BaseGenFunctions {
   val IR: FunctionsExp
   import IR._
 
-  // Nested functions are not allowed in standard C.
-  // TODO: Either emit the function other place or use C++11 (or only gcc)
-  /*
+  // Case for functions with a single argument (therefore, not tupled)
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case e@Lambda(fun, x, y) =>
-      stream.println(remap(y.tp)+" "+quote(sym)+"("+remap(x.tp)+" "+quote(x)+") {")
+      stream.println("auto "+quote(sym)+" = [&]("+remap(x.tp)+" "+quote(x)+") {")
       emitBlock(y)
       val z = getBlockResult(y)
       if (remap(z.tp) != "void")
@@ -361,7 +359,7 @@ trait CGenFunctions extends CGenEffect with BaseGenFunctions {
       emitValDef(sym, quote(fun) + "(" + quote(arg) + ")")
     case _ => super.emitNode(sym, rhs)
   }
-  */
+  
 }
 
 trait CGenTupledFunctions extends CGenFunctions with GenericGenUnboxedTupleAccess {


### PR DESCRIPTION
Extending support of C++11 lambda expression code generation for non-tupled functions (i.e. functions taking only one argument)
