### PR TITLE
if-else C code generation modified to rely on remap

### DIFF
--- a/src/common/IfThenElse.scala
+++ b/src/common/IfThenElse.scala
@@ -384,10 +384,7 @@ trait CGenIfThenElse extends CGenEffect with BaseGenIfThenElse {
             emitBlock(b)
             stream.println("}")
           case _ =>
-            if (isPrimitiveType(sym.tp))
-              stream.println("%s %s;".format(remap(sym.tp),quote(sym)))
-            else
-              stream.println("%s *%s;".format(remap(sym.tp),quote(sym)))
+            stream.println("%s %s;".format(remap(sym.tp),quote(sym)))
             stream.println("if (" + quote(c) + ") {")
             emitBlock(a)
             stream.println("%s = %s;".format(quote(sym),quote(getBlockResult(a))))


### PR DESCRIPTION
if-else C code generation modified to rely on remap to determine whether the return type is primitive or not.

Previously, one indirection level was added by adding a "star" sign, but the rest of the C code generation package relies on remap to determine the exact return type of an IR node (which is by far more convenient IMO). For this reason, I suggest this change that assumes remap will add as many indirection levels as required, which works very neatly in all my DSLs.
