### PR TITLE
Coverage support and coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: scala
 scala:
    - 2.10.2
+
+script:
+    - sbt clean coverage test && sbt coverageAggregate
+
+after_success:
+    - sbt coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,4 @@ scalacOptions += "-P:continuations:enable"
 
 // code coverage
 
-resolvers += Classpaths.sbtPluginReleases
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
-
 scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false

--- a/build.sbt
+++ b/build.sbt
@@ -39,3 +39,13 @@ autoCompilerPlugins := true
 addCompilerPlugin("org.scala-lang.virtualized.plugins" % "continuations" % virtScala)
 
 scalacOptions += "-P:continuations:enable"
+
+// code coverage
+
+resolvers += Classpaths.sbtPluginReleases
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+
+scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,0 +1,5 @@
+resolvers += Classpaths.sbtPluginReleases
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")


### PR DESCRIPTION
This adds the support for automatic coverage report with https://coveralls.io/. Registration on https://coveralls.io/ is required.
