### PR TITLE
Lambda function and if-then-else return value deduction

### DIFF
--- a/src/common/Functions.scala
+++ b/src/common/Functions.scala
@@ -378,8 +378,8 @@ trait CGenTupledFunctions extends CGenFunctions with GenericGenUnboxedTupleAcces
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case Lambda(fun, UnboxedTuple(xs), y) =>
       val retType = remap(getBlockResult(y).tp)
-      stream.println("function<"+retType+"("+
-    		  xs.map(s=>remap(s.tp)).mkString(",")+")> "+quote(sym)+
+      val retTp = if (cppExplicitFunRet == "true") "function<"+retType+"("+xs.map(s=>remap(s.tp)).mkString(",")+")>" else "auto"
+      stream.println(retTp+" "+quote(sym)+
     		  " = [&]("+xs.map(s=>remap(s.tp)+" "+quote(s)).mkString(",")+") {")
       emitBlock(y)
       val z = getBlockResult(y)

--- a/src/common/Functions.scala
+++ b/src/common/Functions.scala
@@ -350,8 +350,8 @@ trait CGenFunctions extends CGenEffect with BaseGenFunctions {
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
     case e@Lambda(fun, x, y) =>
       val retType = remap(getBlockResult(y).tp)
-      stream.println("function<"+retType+"("+
-    		  remap(x.tp)+")> "+quote(sym)+
+      val retTp = if (cppExplicitFunRet == "true") "function<"+retType+"("+remap(x.tp)+")>" else "auto"
+      stream.println(retTp+" "+quote(sym)+
     		  " = [&]("+remap(x.tp)+" "+quote(x)+") {")
       emitBlock(y)
       val z = getBlockResult(y)

--- a/src/common/IfThenElse.scala
+++ b/src/common/IfThenElse.scala
@@ -384,14 +384,17 @@ trait CGenIfThenElse extends CGenEffect with BaseGenIfThenElse {
             emitBlock(b)
             stream.println("}")
           case _ =>
-            stream.println("%s %s;".format(remap(sym.tp),quote(sym)))
-            stream.println("if (" + quote(c) + ") {")
-            emitBlock(a)
-            stream.println("%s = %s;".format(quote(sym),quote(getBlockResult(a))))
-            stream.println("} else {")
-            emitBlock(b)
-            stream.println("%s = %s;".format(quote(sym),quote(getBlockResult(b))))
-            stream.println("}")
+            val ten = quote(sym) + "True"
+            val fen = quote(sym) + "False"
+            def emitCondFun[T: Manifest](fname: String, block: Block[T]) {
+              stream.println("auto " + fname + " = [&]() {");
+              emitBlock(block)
+              stream.println("return " + quote(getBlockResult(block)) + ";")
+              stream.println("};")
+            }
+            emitCondFun(ten, a)
+            emitCondFun(fen, b)
+            stream.println("auto " + quote(sym) + " = " + quote(c) + " ? " + ten + "() : " + fen + "();")
         }
         /*
         val booll = remap(sym.tp).equals("void")

--- a/src/common/IfThenElse.scala
+++ b/src/common/IfThenElse.scala
@@ -384,17 +384,28 @@ trait CGenIfThenElse extends CGenEffect with BaseGenIfThenElse {
             emitBlock(b)
             stream.println("}")
           case _ =>
-            val ten = quote(sym) + "True"
-            val fen = quote(sym) + "False"
-            def emitCondFun[T: Manifest](fname: String, block: Block[T]) {
-              stream.println("auto " + fname + " = [&]() {");
-              emitBlock(block)
-              stream.println("return " + quote(getBlockResult(block)) + ";")
-              stream.println("};")
+            if (cppIfElseAutoRet == "true") {
+              val ten = quote(sym) + "True"
+              val fen = quote(sym) + "False"
+              def emitCondFun[T: Manifest](fname: String, block: Block[T]) {
+                stream.println("auto " + fname + " = [&]() {");
+                emitBlock(block)
+                stream.println("return " + quote(getBlockResult(block)) + ";")
+                stream.println("};")
+              }
+              emitCondFun(ten, a)
+              emitCondFun(fen, b) 
+              stream.println("auto " + quote(sym) + " = " + quote(c) + " ? " + ten + "() : " + fen + "();")
+            } else {
+              stream.println("%s %s;".format(remap(sym.tp),quote(sym)))
+              stream.println("if (" + quote(c) + ") {")
+              emitBlock(a)
+              stream.println("%s = %s;".format(quote(sym),quote(getBlockResult(a))))
+              stream.println("} else {")
+              emitBlock(b)
+              stream.println("%s = %s;".format(quote(sym),quote(getBlockResult(b))))
+              stream.println("}")
             }
-            emitCondFun(ten, a)
-            emitCondFun(fen, b)
-            stream.println("auto " + quote(sym) + " = " + quote(c) + " ? " + ten + "() : " + fen + "();")
         }
         /*
         val booll = remap(sym.tp).equals("void")

--- a/src/common/MathOps.scala
+++ b/src/common/MathOps.scala
@@ -28,7 +28,7 @@ trait MathOps extends Base {
     def abs[A:Manifest:Numeric](x: Rep[A])(implicit pos: SourceContext) = math_abs(x)
     def max[A:Manifest:Numeric](x: Rep[A], y: Rep[A])(implicit pos: SourceContext) = math_max(x,y)
     def min[A:Manifest:Numeric](x: Rep[A], y: Rep[A])(implicit pos: SourceContext) = math_min(x,y)
-    def Pi(implicit pos: SourceContext) = math_pi
+    def Pi(implicit pos: SourceContext) = 3.141592653589793238462643383279502884197169
     def E(implicit pos: SourceContext) = math_e
   }
 

--- a/src/internal/Config.scala
+++ b/src/internal/Config.scala
@@ -8,4 +8,7 @@ trait Config {
   
   // memory management type for C++ target (refcnt or gc)
   val cppMemMgr = System.getProperty("lms.cpp.memmgr","malloc")
+  
+  // explicit return type of lambda functions (allows recursive functions but is less generic)
+  val cppExplicitFunRet = System.getProperty("lms.cpp.explicitFunRet","true")
 }

--- a/src/internal/Config.scala
+++ b/src/internal/Config.scala
@@ -11,4 +11,7 @@ trait Config {
   
   // explicit return type of lambda functions (allows recursive functions but is less generic)
   val cppExplicitFunRet = System.getProperty("lms.cpp.explicitFunRet","true")
+  
+  // auto return value of if-else expressions (allows type deduction on if-then-else expressions)
+  val cppIfElseAutoRet = System.getProperty("lms.cpp.ifElseAutoRet","false")
 }


### PR DESCRIPTION
Added support for return type deduction on C++14-like functions and if-then-else constructs. Both changes are only active if the corresponding properties are set in Config.scala for backward compatibility with OpenCL C, CUDA, etc.
